### PR TITLE
Remove OC check

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/proxy/CommonProxy.java
+++ b/src/main/java/cam72cam/immersiverailroading/proxy/CommonProxy.java
@@ -167,9 +167,6 @@ public abstract class CommonProxy implements IGuiHandler {
     		modRegistry.remove(new ResourceLocation("immersiverailroading:manual_iron"));
     		modRegistry.remove(new ResourceLocation("immersiverailroading:track blueprint_iron"));
     	}
-	if (!OreDictionary.doesOreNameExist("oc:materialCard")) {
-    		modRegistry.remove(new ResourceLocation("immersiverailroading:radio_card"));
-    	}
     }
     
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Recipe uses oredict, thus does not matter if OC doesn't exist.
In order for this check to work properly OC needs to be loaded before IR, which is unnecessary trouble.